### PR TITLE
Use native JS instead of jQuery where possible

### DIFF
--- a/drupal-permission-clicker.js
+++ b/drupal-permission-clicker.js
@@ -52,6 +52,6 @@ function clickPermissions(mapping, profile) {
     });
   }
   else {
-    console.log('Error: Can not load ' + profile + '.js file');
+    console.error('Error: Can not load ' + profile + '.js file');
   }
 }

--- a/drupal-permission-getter.js
+++ b/drupal-permission-getter.js
@@ -9,8 +9,7 @@ function getPermissions() {
   var result = [];
 
   jQuery('input:checked').each(function() {
-    var $checkbox = jQuery(this),
-      data = $checkbox.attr('name').replace(']', '').split('[');
+    var data = this.name.replace(']', '').split('[');
 
     if (data[0]) {
       if (!result[data[0]]) {


### PR DESCRIPTION
### Changes

- Remove redundant variable and method call since they are unneeded.
- Replace `console.log()` by `console.error()` for reporting errors to developers.